### PR TITLE
Add CSS support for google icons that was missing in original PR.

### DIFF
--- a/client/style.css
+++ b/client/style.css
@@ -3,6 +3,29 @@ body {
   font-family: sans-serif;
 }
 
+@font-face {
+  font-family: 'Material Icons';
+  font-style: normal;
+  font-weight: 400;
+  src: url(https://fonts.gstatic.com/s/materialicons/v88/flUhRq6tzZclQEJ-Vdg-IuiaDsNcIhQ8tQ.woff2) format('woff2');
+}
+
+.material-icons {
+  font-family: 'Material Icons';
+  font-weight: normal;
+  font-style: normal;
+  font-size: 24px;
+  line-height: 1;
+  letter-spacing: normal;
+  text-transform: none;
+  display: inline-block;
+  white-space: nowrap;
+  word-wrap: normal;
+  direction: ltr;
+  -webkit-font-feature-settings: 'liga';
+  -webkit-font-smoothing: antialiased;
+}
+
 h1{
   font-family: Impact, Haettenschweiler, 'Arial Narrow Bold', sans-serif;
 }


### PR DESCRIPTION
The previous PR to add the google Icons was missing a key piece: The CSS class & font declaration needed to actually use the icons after installing them.