### PR TITLE
Add styling to the StarReview component

### DIFF
--- a/client/__tests__/StarReview.test.js
+++ b/client/__tests__/StarReview.test.js
@@ -15,15 +15,15 @@ test('Should render StarReview component', () => {
 test('Should render 5 full stars on a 5', () => {
   render(<StarReview rating={5} />);
   const StarReviewComponent = screen.getByTestId('star-review');
-  const numberOfFullStars = screen.getAllByAltText('Full star');
+  const numberOfFullStars = screen.getAllByTitle('Full star');
   expect(numberOfFullStars.length).toBe(5);
 });
 
 test('Should render 2 full stars and 3 empty stars on a 2', () => {
   render(<StarReview rating={2} />);
   const StarReviewComponent = screen.getByTestId('star-review');
-  const numberOfFullStars = screen.getAllByAltText('Full star');
-  const numberOfEmptyStars = screen.getAllByAltText('Empty star');
+  const numberOfFullStars = screen.getAllByTitle('Full star');
+  const numberOfEmptyStars = screen.getAllByTitle('Empty star');
   expect(numberOfFullStars.length).toBe(2);
   expect(numberOfEmptyStars.length).toBe(3);
 });
@@ -31,9 +31,9 @@ test('Should render 2 full stars and 3 empty stars on a 2', () => {
 test('Should render 1 full star, 1 half star and 3 empty stars on a 1.5', () => {
   render(<StarReview rating={1.5} />);
   const StarReviewComponent = screen.getByTestId('star-review');
-  const numberOfFullStars = screen.getAllByAltText('Full star');
-  const numberOfHalfStars = screen.getAllByAltText('Half star');
-  const numberOfEmptyStars = screen.getAllByAltText('Empty star');
+  const numberOfFullStars = screen.getAllByTitle('Full star');
+  const numberOfHalfStars = screen.getAllByTitle('Half star');
+  const numberOfEmptyStars = screen.getAllByTitle('Empty star');
   expect(numberOfFullStars.length).toBe(1);
   expect(numberOfHalfStars.length).toBe(1);
   expect(numberOfEmptyStars.length).toBe(3);
@@ -42,9 +42,9 @@ test('Should render 1 full star, 1 half star and 3 empty stars on a 1.5', () => 
 test('Should render 1 full star, 1 three quarter star and 3 empty stars on a 1.9', () => {
   render(<StarReview rating={1.9} />);
   const StarReviewComponent = screen.getByTestId('star-review');
-  const numberOfFullStars = screen.getAllByAltText('Full star');
-  const numberOfHalfStars = screen.getAllByAltText('Three quarter star');
-  const numberOfEmptyStars = screen.getAllByAltText('Empty star');
+  const numberOfFullStars = screen.getAllByTitle('Full star');
+  const numberOfHalfStars = screen.getAllByTitle('Three quarter star');
+  const numberOfEmptyStars = screen.getAllByTitle('Empty star');
   expect(numberOfFullStars.length).toBe(1);
   expect(numberOfHalfStars.length).toBe(1);
   expect(numberOfEmptyStars.length).toBe(3);
@@ -53,9 +53,9 @@ test('Should render 1 full star, 1 three quarter star and 3 empty stars on a 1.9
 test('Should render 1 full star, 3 empty stars and 1 quarter star on a 1.4', () => {
   render(<StarReview rating={1.4} />);
   const StarReviewComponent = screen.getByTestId('star-review');
-  const numberOfFullStars = screen.getAllByAltText('Full star');
-  const numberOfEmptyStars = screen.getAllByAltText('Empty star');
-  const numberOfQuarterStars = screen.getAllByAltText('Quarter star');
+  const numberOfFullStars = screen.getAllByTitle('Full star');
+  const numberOfEmptyStars = screen.getAllByTitle('Empty star');
+  const numberOfQuarterStars = screen.getAllByTitle('Quarter star');
   expect(numberOfFullStars.length).toBe(1);
   expect(numberOfEmptyStars.length).toBe(3);
   expect(numberOfQuarterStars.length).toBe(1);
@@ -64,8 +64,8 @@ test('Should render 1 full star, 3 empty stars and 1 quarter star on a 1.4', () 
 test('Should render 1 full star, 0 half stars and 4 empty stars on a 1.2', () => {
   render(<StarReview rating={1.2} />);
   const StarReviewComponent = screen.getByTestId('star-review');
-  const numberOfFullStars = screen.getAllByAltText('Full star');
-  const numberOfEmptyStars = screen.getAllByAltText('Empty star');
+  const numberOfFullStars = screen.getAllByTitle('Full star');
+  const numberOfEmptyStars = screen.getAllByTitle('Empty star');
   expect(numberOfFullStars.length).toBe(1);
   expect(numberOfEmptyStars.length).toBe(4);
 });

--- a/client/src/components/StarReview.jsx
+++ b/client/src/components/StarReview.jsx
@@ -6,23 +6,43 @@ const StarReview = ({ rating }) => {
   const totalStars = 5;
   // Add a full star for every whole number
   for (let i = 0; i < Math.floor(rating); i++) {
-    stars.push(<div className="star-review__star star-review__star--full" key={i}><img src="#" alt="Full star" /></div>);
+    stars.push(
+      <div className="star-review__star star-review__star--full" key={i}>
+        <span className="material-icons">star_outline</span>
+      </div>
+    );
   }
   // If decimal between .75 and 1, show 3/4-star graphic
   if ((rating - stars.length) >= .75) {
-    stars.push(<div className="star-review__star star-review__star--threequarter" key={1}><img src="#" alt="Three quarter star" /></div>);
+    stars.push(
+      <div className="star-review__star star-review__star--threequarter" key={1}>
+        <span className="material-icons">star_outline</span>
+      </div>
+    );
   }
   // If decimal between .5 and .75, show half-star graphic
   if ((rating - stars.length) >= .5) {
-    stars.push(<div className="star-review__star star-review__star--half" key={1}><img src="#" alt="Half star" /></div>);
+    stars.push(
+      <div className="star-review__star star-review__star--half" key={1}>
+        <span className="material-icons">star_outline</span>
+      </div>
+    );
   }
   // If decimal between .25 and .5, show 1/4-star graphic
   if ((rating - stars.length) >= .25) {
-    stars.push(<div className="star-review__star star-review__star--quarter" key={1}><img src="#" alt="Quarter star" /></div>);
+    stars.push(
+      <div className="star-review__star star-review__star--quarter" key={1}>
+        <span className="material-icons">star_outline</span>
+      </div>
+    );
   }
   // Fill the rest with empty stars
   for (let i = stars.length; i < totalStars; i++) {
-    stars.push(<div className="star-review__star star-review__star--empty" key={i}><img src="#" alt="Empty star" /></div>);
+    stars.push(
+      <div className="star-review__star star-review__star--empty" key={i}>
+        <span className="material-icons">star_outline</span>
+      </div>
+    );
   }
 
   return <div className="star-review" data-testid="star-review">{stars}</div>;

--- a/client/src/components/StarReview.jsx
+++ b/client/src/components/StarReview.jsx
@@ -7,7 +7,7 @@ const StarReview = ({ rating }) => {
   // Add a full star for every whole number
   for (let i = 0; i < Math.floor(rating); i++) {
     stars.push(
-      <div className="star-review__star star-review__star--full" key={i}>
+      <div className="star-review__star star-review__star--full" title="Full star" key={i}>
         <span className="material-icons">star_outline</span>
       </div>
     );
@@ -15,7 +15,7 @@ const StarReview = ({ rating }) => {
   // If decimal between .75 and 1, show 3/4-star graphic
   if ((rating - stars.length) >= .75) {
     stars.push(
-      <div className="star-review__star star-review__star--threequarter" key={1}>
+      <div className="star-review__star star-review__star--threequarter" title="Three quarter star" key={1}>
         <span className="material-icons">star_outline</span>
       </div>
     );
@@ -23,7 +23,7 @@ const StarReview = ({ rating }) => {
   // If decimal between .5 and .75, show half-star graphic
   if ((rating - stars.length) >= .5) {
     stars.push(
-      <div className="star-review__star star-review__star--half" key={1}>
+      <div className="star-review__star star-review__star--half" title="Half star" key={1}>
         <span className="material-icons">star_outline</span>
       </div>
     );
@@ -31,7 +31,7 @@ const StarReview = ({ rating }) => {
   // If decimal between .25 and .5, show 1/4-star graphic
   if ((rating - stars.length) >= .25) {
     stars.push(
-      <div className="star-review__star star-review__star--quarter" key={1}>
+      <div className="star-review__star star-review__star--quarter" title="Quarter star" key={1}>
         <span className="material-icons">star_outline</span>
       </div>
     );
@@ -39,7 +39,7 @@ const StarReview = ({ rating }) => {
   // Fill the rest with empty stars
   for (let i = stars.length; i < totalStars; i++) {
     stars.push(
-      <div className="star-review__star star-review__star--empty" key={i}>
+      <div className="star-review__star star-review__star--empty" title="Empty star" key={i}>
         <span className="material-icons">star_outline</span>
       </div>
     );

--- a/client/src/components/StarReview.jsx
+++ b/client/src/components/StarReview.jsx
@@ -15,7 +15,7 @@ const StarReview = ({ rating }) => {
   // If decimal between .75 and 1, show 3/4-star graphic
   if ((rating - stars.length) >= .75) {
     stars.push(
-      <div className="star-review__star star-review__star--threequarter" title="Three quarter star" key={1}>
+      <div className="star-review__star star-review__star--threequarter" title="Three quarter star" key={'threequarter'}>
         <span className="material-icons">star_outline</span>
       </div>
     );
@@ -23,7 +23,7 @@ const StarReview = ({ rating }) => {
   // If decimal between .5 and .75, show half-star graphic
   if ((rating - stars.length) >= .5) {
     stars.push(
-      <div className="star-review__star star-review__star--half" title="Half star" key={1}>
+      <div className="star-review__star star-review__star--half" title="Half star" key={'half'}>
         <span className="material-icons">star_outline</span>
       </div>
     );
@@ -31,7 +31,7 @@ const StarReview = ({ rating }) => {
   // If decimal between .25 and .5, show 1/4-star graphic
   if ((rating - stars.length) >= .25) {
     stars.push(
-      <div className="star-review__star star-review__star--quarter" title="Quarter star" key={1}>
+      <div className="star-review__star star-review__star--quarter" title="Quarter star" key={'quarter'}>
         <span className="material-icons">star_outline</span>
       </div>
     );

--- a/client/style.css
+++ b/client/style.css
@@ -194,3 +194,35 @@ h1{
   margin: 1px;
   cursor: pointer;
 }
+
+/* || StarReview */
+
+.star-review__star {
+  display: inline-block;
+}
+.star-review__star > span {
+  font-size: 1em;
+  position: relative;
+}
+.star-review__star > span::after {
+  content: '\e838';
+  position: absolute;
+  top: 0;
+  left: 0;
+  overflow: hidden;
+}
+.star-review__star--full > span::after {
+  width: 100%;
+}
+.star-review__star--threequarter > span::after {
+  width: 58%;
+}
+.star-review__star--half > span::after {
+  width: 50%;
+}
+.star-review__star--quarter > span::after {
+  width: 42%;
+}
+.star-review__star--empty > span::after {
+  width: 0;
+}


### PR DESCRIPTION
Now has styling for the StarReview component. Sizing will be something to consider for components later on, but it is currently sized at 1em, which will refer to the nearest parent's defined font-size. So I *think* it should be adaptable.

![Screen Shot 2021-06-02 at 7 25 19 PM](https://user-images.githubusercontent.com/65684361/120576860-4c933480-c3d8-11eb-84e4-ae3b2937cffe.png)
