### PR TITLE
Allow resizing of Carousel to trigger checking of whether scroll buttons should exist

### DIFF
--- a/client/src/components/RelatedItemsAndOutfit/Carousel.jsx
+++ b/client/src/components/RelatedItemsAndOutfit/Carousel.jsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useState, createRef } from 'react';
+import React, { createRef } from 'react';
 import Card from './Card.jsx';
 import AddToOutfitCard from './AddToOutfitCard.jsx';
 import NoRelatedProductsCard from './NoRelatedProductsCard.jsx';

--- a/client/src/components/RelatedItemsAndOutfit/Carousel.jsx
+++ b/client/src/components/RelatedItemsAndOutfit/Carousel.jsx
@@ -2,6 +2,7 @@ import React, { useCallback, useEffect, useState, createRef } from 'react';
 import Card from './Card.jsx';
 import AddToOutfitCard from './AddToOutfitCard.jsx';
 import NoRelatedProductsCard from './NoRelatedProductsCard.jsx';
+import debounce from '../../scripts/debounce';
 import calculateRating from '../../scripts/calculateRating';
 
 class Carousel extends React.Component {
@@ -10,8 +11,10 @@ class Carousel extends React.Component {
     const screenWidth = window.innerWidth;
     const cardWidth = 272; // px
     const capacity = Math.floor(screenWidth / cardWidth); // number of cards that can fit across
+    const numberOfCards = this.getNumberOfCards();
     this.state = {
       products: this.props.products,
+      numberOfCards,
       productCards: [],
       // Scroll Info
       screenWidth,
@@ -21,9 +24,14 @@ class Carousel extends React.Component {
       cardWidth,
       capacity,
       farLeft: 0,
-      farRight: Math.max(this.props.products.length - capacity, 0), // number of scrolls you can make
+      farRight: Math.max(numberOfCards - capacity, 0), // number of scrolls you can make
     };
-    this.slideWrapperRef = createRef();
+    this.outerWrapperRef = createRef();
+    this.innerWrapperRef = createRef();
+  }
+
+  getNumberOfCards() {
+    return this.props.carouselType === 'outfit' ? this.props.products.length + 1 : this.props.products.length;
   }
 
   createProductCards() {
@@ -36,40 +44,56 @@ class Carousel extends React.Component {
     });
   }
 
-  componentWillMount() {
+  componentDidMount() {
     this.scrollAndSetCarousel();
+    const debouncedScrollAndSetCarousel = debounce(() => this.scrollAndSetCarousel());
+    window.addEventListener('resize', () => {
+      this.setState({
+        screenWidth: this.innerWrapperRef.current.scrollWidth,
+      });
+      debouncedScrollAndSetCarousel();
+    });
   }
 
   componentDidUpdate(prevProps, prevState, snapshot) {
     if (this.props !== prevProps) {
       this.setState({
         products: this.props.products,
+        numberOfCards: this.getNumberOfCards(),
         productCards: this.createProductCards(),
-        farRight: Math.max(this.props.products.length - this.state.capacity, 0),
-        screenWidth: window.innerWidth,
       });
       this.scrollAndSetCarousel();
     }
   }
 
-  scrollAndSetCarousel(change = 0, numberOfProducts = this.state.products.length) {
+  scrollAndSetCarousel(change = 0, numberOfProducts = this.state.numberOfCards) {
     // If you can't scroll in a direction, remove the button
+    const capacity = Math.floor(this.state.screenWidth / this.state.cardWidth);
+    const farRight = Math.max(this.state.numberOfCards - capacity, 0);
     this.setState({
-      canScrollLeft: this.state.scrollPosition + change > this.state.farLeft,
-      canScrollRight: this.state.scrollPosition + change < this.state.farRight,
-    });
+      canScrollLeft: this.state.scrollPosition > this.state.farLeft,
+      canScrollRight: this.state.scrollPosition < farRight,
+      screenWidth: this.state.screenWidth,
+      capacity,
+      farRight,
+    }, () => {
+      // If you are not at the edge, then scroll one more card over
+      if ((change === -1 && this.state.scrollPosition > this.state.farLeft) || (change === 1 && this.state.scrollPosition < this.state.farRight)) {
+        // console.log(this.state.scrollPosition, change, this.state.farRight);
+        // console.log(this.state.scrollPosition + change < this.state.farRight);
 
-    // If you are not at the edge, then scroll one more card over
-    if ((change === -1 && this.state.scrollPosition !== this.state.farLeft) || (change === 1 && this.state.scrollPosition !== this.state.farRight)) {
-      this.setState({
-        scrollPosition: this.state.scrollPosition + change
-      });
-    }
+        this.setState({
+          canScrollLeft: this.state.scrollPosition + change > this.state.farLeft,
+          canScrollRight: this.state.scrollPosition + change < this.state.farRight,
+          scrollPosition: this.state.scrollPosition + change
+        });
+      }
+    });
   }
 
   render() {
     return (
-      <div className="carousel__wrapper">
+      <div className="carousel__wrapper" ref={this.outerWrapperRef}>
         <div
           className="carousel__edge carousel__edge--left"
           style={{
@@ -85,7 +109,7 @@ class Carousel extends React.Component {
             arrow_backward
           </span>
         </div>
-        <div ref={this.slideWrapperRef} className="carousel__slide-wrapper">
+        <div ref={this.innerWrapperRef} className="carousel__slide-wrapper">
           <div
             className="carousel"
             style={{ left: String(this.state.scrollPosition * -272) + 'px' }}
@@ -96,13 +120,13 @@ class Carousel extends React.Component {
             )}
             {this.props.carouselType === 'outfit' && (
               <AddToOutfitCard
-                currentProduct={this.state.currentProduct}
+                currentProduct={this.props.currentProduct}
                 onAction={this.props.onAction}
               />
             )}
             {this.state.productCards.map((productCard, index) => (
               <Card
-                top={top}
+                top={this.props.top}
                 key={index}
                 product={productCard}
                 cardType={this.props.carouselType}

--- a/client/src/components/RelatedItemsAndOutfit/Carousel.jsx
+++ b/client/src/components/RelatedItemsAndOutfit/Carousel.jsx
@@ -8,25 +8,21 @@ import calculateRating from '../../scripts/calculateRating';
 class Carousel extends React.Component {
   constructor(props) {
     super(props); // ({ top, currentProduct, products, carouselType, onAction })
-    const screenWidth = window.innerWidth;
-    const cardWidth = 272; // px
-    const capacity = Math.floor(screenWidth / cardWidth); // number of cards that can fit across
-    const numberOfCards = this.getNumberOfCards();
     this.state = {
+      // Product Info
       products: this.props.products,
-      numberOfCards,
-      productCards: [],
+      numberOfCards: this.getNumberOfCards(),
+      productCards: this.createProductCards(),
       // Scroll Info
-      screenWidth,
+      screenWidth: 0,
       scrollPosition: 0,
       canScrollLeft: false,
       canScrollRight: false,
-      cardWidth,
-      capacity,
+      cardWidth: 272, // px
+      capacity: 0,
       farLeft: 0,
-      farRight: Math.max(numberOfCards - capacity, 0), // number of scrolls you can make
+      farRight: 0,
     };
-    this.outerWrapperRef = createRef();
     this.innerWrapperRef = createRef();
   }
 
@@ -46,11 +42,13 @@ class Carousel extends React.Component {
 
   componentDidMount() {
     this.scrollAndSetCarousel();
+    // Set window listener to set scrolling on resize
     const debouncedScrollAndSetCarousel = debounce(() => this.scrollAndSetCarousel());
     window.addEventListener('resize', () => {
       this.setState({
         screenWidth: this.innerWrapperRef.current.scrollWidth,
-      });
+        farRight: Math.max(this.state.numberOfCards - capacity, 0), // number of times user can scroll to the right
+      }, () => console.log(this.state.productCards));
       debouncedScrollAndSetCarousel();
     });
   }
@@ -66,6 +64,7 @@ class Carousel extends React.Component {
     }
   }
 
+  // When no vars are passed in, this will just set the state re: scrolling the Carousel
   scrollAndSetCarousel(change = 0, numberOfProducts = this.state.numberOfCards) {
     // If you can't scroll in a direction, remove the button
     const capacity = Math.floor(this.state.screenWidth / this.state.cardWidth);
@@ -77,11 +76,8 @@ class Carousel extends React.Component {
       capacity,
       farRight,
     }, () => {
-      // If you are not at the edge, then scroll one more card over
+      // If you are not at either edge, scroll over one card
       if ((change === -1 && this.state.scrollPosition > this.state.farLeft) || (change === 1 && this.state.scrollPosition < this.state.farRight)) {
-        // console.log(this.state.scrollPosition, change, this.state.farRight);
-        // console.log(this.state.scrollPosition + change < this.state.farRight);
-
         this.setState({
           canScrollLeft: this.state.scrollPosition + change > this.state.farLeft,
           canScrollRight: this.state.scrollPosition + change < this.state.farRight,
@@ -93,7 +89,7 @@ class Carousel extends React.Component {
 
   render() {
     return (
-      <div className="carousel__wrapper" ref={this.outerWrapperRef}>
+      <div className="carousel__wrapper">
         <div
           className="carousel__edge carousel__edge--left"
           style={{

--- a/client/src/scripts/__tests__/debounce.test.js
+++ b/client/src/scripts/__tests__/debounce.test.js
@@ -1,0 +1,18 @@
+import debounce from '../debounce';
+
+it('Should not run the function more than once within a given period', () => {
+  let counter = 0;
+  const incrementCounter = () => counter++;
+  const debouncedIncrementCounter = () => debounce(incrementCounter(), 100);
+  incrementCounter();
+  expect(counter).toBe(1);
+  setTimeout(() => debouncedIncrementCounter(), 10);
+  setTimeout(() => debouncedIncrementCounter(), 20);
+  setTimeout(() => debouncedIncrementCounter(), 50);
+  setTimeout(() => debouncedIncrementCounter(), 100);
+  setTimeout(() => debouncedIncrementCounter(), 150);
+  // 99ms after the last call, the counter should not be incremented
+  setTimeout(() => expect(counter).notToBe(2), 249);
+  // 100ms after the last call, the counter should be incremented
+  setTimeout(() => expect(counter).toBe(2), 250);
+});

--- a/client/src/scripts/debounce.js
+++ b/client/src/scripts/debounce.js
@@ -1,0 +1,7 @@
+export default (fn, timeout = 150) => {
+  let timeoutId;
+  return (...args) => {
+    clearTimeout(timeoutId);
+    timeoutId = setTimeout(() => fn.apply(this, args), timeout);
+  };
+};


### PR DESCRIPTION
When the user resizes the window, it will now check whether or not all the cards are visible, will give the user buttons to scroll if not, and remove the buttons if yes.